### PR TITLE
Add option in sttings for custom HTMLField class.

### DIFF
--- a/dbmail/__init__.py
+++ b/dbmail/__init__.py
@@ -131,3 +131,43 @@ def python_2_unicode_compatible(klass):
         klass.__unicode__ = klass.__str__
         klass.__str__ = lambda self: self.__unicode__().encode('utf-8')
     return klass
+
+
+def import_by_string(dotted_path):
+    """Import class by his full module path.
+
+    Function for compability of different Django versions.
+
+    Args:
+        dotted_path - string, full import path for class.
+
+    """
+
+    import_string = None
+
+    # Django >= 1.5, < 1.7
+    try:
+        from django.utils.module_loading import import_by_path as import_string
+    except ImportError:
+        import_string = import_string
+
+    # Django >= 1.7
+    try:
+        from django.utils.module_loading import import_string
+    except ImportError:
+        import_string = import_string
+
+    if import_string is not None:
+        return import_string(dotted_path)
+
+    # Django == 1.4
+
+    from django.utils.importlib import import_module
+
+    class_data = dotted_path.split('.')
+    module_path = '.'.join(class_data[:-1])
+    class_str = class_data[-1]
+
+    module = import_module(module_path)
+    # Finally, we retrieve the Class
+    return getattr(module, class_str)

--- a/dbmail/defaults.py
+++ b/dbmail/defaults.py
@@ -98,3 +98,6 @@ IGNORE_BROWSE_APP = get_settings(
         'south', 'dbmail', 'sessions', 'admin', 'djcelery',
         'auth', 'reversion', 'contenttypes'
     ])
+
+MODEL_HTMLFIELD = get_settings(
+    'DB_MAILER_MODEL_HTMLFIELD', 'django.db.models.TextField')

--- a/dbmail/fields.py
+++ b/dbmail/fields.py
@@ -1,21 +1,7 @@
 # -*- encoding: utf-8 -*-
 
-from django.db import models
+from dbmail import import_by_string
+from dbmail.defaults import MODEL_HTMLFIELD
 
-from dbmail import app_installed
 
-HTMLField = models.TextField
-
-if app_installed('tinymce'):
-    try:
-        from tinymce.models import HTMLField
-
-    except ImportError:
-        pass
-
-if app_installed('ckeditor'):
-    try:
-        from ckeditor.fields import RichTextField as HTMLField
-
-    except ImportError:
-        pass
+HTMLField = import_by_string(MODEL_HTMLFIELD)

--- a/docs/conf.rst
+++ b/docs/conf.rst
@@ -180,3 +180,6 @@ App settings
 
     # Function for transform html to text
     DB_MAILER_MESSAGE_HTML2TEXT = 'dbmail.utils'
+
+    # Path to HTMLField class.
+    DB_MAILER_MODEL_HTMLFIELD = 'django.db.models.TextField'


### PR DESCRIPTION
Пользуюсь Вашим проектом и решил немного его улучшить.

Вместо кучи блоков try/except в фале fields.py для всех мыслимых пользовательских HTML-полей для модели, я запилил импорт по строке вида 'app.fields.MyCustomModelHTMLField'.

Теперь совсем не обязательно, чтобы батарейка, из которой берётся поле, была в INSTALLED_APPS. Достаточно, чтобы она просто была в доступна для импорта.
