### PR TITLE
bugfix MRO problem using modeltranslation.

### DIFF
--- a/dbmail/admin.py
+++ b/dbmail/admin.py
@@ -52,7 +52,7 @@ if app_installed('modeltranslation'):
         try:
             from modeltranslation.admin import TabbedTranslationAdmin
 
-            class TranslationModelAdmin(TabbedTranslationAdmin):
+            class TranslationModelAdmin(TabbedTranslationAdmin, ModelAdmin):
                 pass
         except ImportError:
             pass

--- a/dbmail/admin.py
+++ b/dbmail/admin.py
@@ -3,7 +3,6 @@
 import os
 
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import ugettext_lazy as _
 from django.shortcuts import redirect, render
 from django.core.urlresolvers import reverse
@@ -53,7 +52,7 @@ if app_installed('modeltranslation'):
         try:
             from modeltranslation.admin import TabbedTranslationAdmin
 
-            class TranslationModelAdmin(ModelAdmin, TabbedTranslationAdmin):
+            class TranslationModelAdmin(TabbedTranslationAdmin):
                 pass
         except ImportError:
             pass


### PR DESCRIPTION
Resolve #38 

Reading the code of https://github.com/deschler/django-modeltranslation/blob/master/modeltranslation/admin.py, we can see that "TabbedTranslationAdmin" class already inherit ModelAdmin.
