### PR TITLE
Remove unused 'django.conf.urls import patterns'

### DIFF
--- a/dbmail/admin.py
+++ b/dbmail/admin.py
@@ -6,7 +6,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import ugettext_lazy as _
 from django.shortcuts import redirect, render
 from django.core.urlresolvers import reverse
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.contrib import messages
 from django.contrib import admin
 


### PR DESCRIPTION
It is necessary because 'patterns' doesn't exist since django 1.10
