### PR TITLE
Update urls.py for Django 1.10

### DIFF
--- a/dbmail/urls.py
+++ b/dbmail/urls.py
@@ -1,17 +1,17 @@
 # -*- encoding: utf-8 -*-
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from dbmail.views import (
+    send_by_dbmail, mail_read_tracker,
     SafariPushPackagesView, SafariSubscriptionView, SafariLogView,
     PushSubscriptionView
 )
 
-urlpatterns = patterns(
-    'dbmail.views',
-    url(r'^api/', 'send_by_dbmail', name='db-mail-api'),
+urlpatterns = [
+    url(r'^api/', send_by_dbmail, name='db-mail-api'),
     url(r'^mail_read_tracker/(.*?)/$',
-        'mail_read_tracker', name='db-mail-tracker'),
+        mail_read_tracker, name='db-mail-tracker'),
 
     url(r'^safari/v(?P<version>[0-9]{1})/pushPackages/(?P<site_pid>[.\w-]+)/?',
         SafariPushPackagesView.as_view()),
@@ -24,4 +24,4 @@ urlpatterns = patterns(
         PushSubscriptionView.as_view(), name='push-subscribe'),
     url(r'^(?P<reg_type>web-push|mobile)/unsubscribe/',
         PushSubscriptionView.as_view(), name='push-unsubscribe'),
-)
+]


### PR DESCRIPTION
patterns was removed from django.conf.urls and views must imported instead of string names.

