### PR TITLE
Add support for GeoIP2

### DIFF
--- a/dbmail/defaults.py
+++ b/dbmail/defaults.py
@@ -73,6 +73,7 @@ SIGNAL_DB_DEFERRED_PURGE = get_settings(
     'DB_MAILER_SIGNAL_DB_DEFERRED_PURGE', True)
 
 TRACK_ENABLE = get_settings('DB_MAILER_TRACK_ENABLE', True)
+TRACK_USE_GEOIP2 = get_settings('DB_MAILER_TRACK_USE_GEOIP2', False)
 TRACK_PIXEL = get_settings(
     'DB_MAILER_TRACK_PIXEL',
     [

--- a/dbmail/models.py
+++ b/dbmail/models.py
@@ -723,8 +723,8 @@ class MailLogTrack(models.Model):
                 from django.contrib.gis.geoip import GeoIPException
             else:
                 from django.contrib.gis.geoip2 import GeoIP2 as GeoIP
-                from django.contrib.gis.geoip2 import GeoIPException2\
-                as GeoIPException
+                from django.contrib.gis.geoip2 import GeoIP2Exception\
+                                                    as GeoIPException
             try:
                 g = GeoIP()
                 info = g.city(self.ip) or dict()

--- a/dbmail/models.py
+++ b/dbmail/models.py
@@ -724,7 +724,7 @@ class MailLogTrack(models.Model):
             else:
                 from django.contrib.gis.geoip2 import GeoIP2 as GeoIP
                 from django.contrib.gis.geoip2 import GeoIP2Exception\
-                                                    as GeoIPException
+                    as GeoIPException
             try:
                 g = GeoIP()
                 info = g.city(self.ip) or dict()

--- a/dbmail/models.py
+++ b/dbmail/models.py
@@ -719,10 +719,12 @@ class MailLogTrack(models.Model):
     def detect_geo(self):
         if self.ip and self.counter == 0:
             if not TRACK_USE_GEOIP2:
-                from django.contrib.gis.geoip import GeoIP, GeoIPException
+                from django.contrib.gis.geoip import GeoIP
+                from django.contrib.gis.geoip import GeoIPException
             else:
                 from django.contrib.gis.geoip2 import GeoIP2 as GeoIP
-                from django.contrib.gis.geoip2 import GeoIPException2 as GeoIPException
+                from django.contrib.gis.geoip2 import GeoIPException2\
+                as GeoIPException
             try:
                 g = GeoIP()
                 info = g.city(self.ip) or dict()

--- a/dbmail/models.py
+++ b/dbmail/models.py
@@ -19,7 +19,7 @@ from dbmail.defaults import (
     PRIORITY_STEPS, UPLOAD_TO, DEFAULT_CATEGORY, AUTH_USER_MODEL,
     DEFAULT_FROM_EMAIL, DEFAULT_PRIORITY, CACHE_TTL,
     BACKEND, _BACKEND, BACKENDS_MODEL_CHOICES, MODEL_HTMLFIELD,
-    MODEL_SUBSCRIPTION_DATA_FIELD, SORTED_BACKEND_CHOICES
+    MODEL_SUBSCRIPTION_DATA_FIELD, SORTED_BACKEND_CHOICES, TRACK_USE_GEOIP2
 )
 
 from dbmail import initial_signals, import_by_string
@@ -718,7 +718,7 @@ class MailLogTrack(models.Model):
 
     def detect_geo(self):
         if self.ip and self.counter == 0:
-            if not defaults.TRACK_USE_GEOIP2:
+            if not TRACK_USE_GEOIP2:
                 from django.contrib.gis.geoip import GeoIP, GeoIPException
             else:
                 from django.contrib.gis.geoip2 import GeoIP2 as GeoIP

--- a/dbmail/models.py
+++ b/dbmail/models.py
@@ -718,8 +718,11 @@ class MailLogTrack(models.Model):
 
     def detect_geo(self):
         if self.ip and self.counter == 0:
-            from django.contrib.gis.geoip import GeoIP, GeoIPException
-
+            if not defaults.TRACK_USE_GEOIP2:
+                from django.contrib.gis.geoip import GeoIP, GeoIPException
+            else:
+                from django.contrib.gis.geoip2 import GeoIP2 as GeoIP
+                from django.contrib.gis.geoip2 import GeoIPException2 as GeoIPException
             try:
                 g = GeoIP()
                 info = g.city(self.ip) or dict()


### PR DESCRIPTION
https://github.com/LPgenerator/django-db-mailer/issues/98
- Add choose between GeoIP and GeoIP2 (default: GeoIP)
- Add setting `DB_MAILER_TRACK_USE_GEOIP2`