### PR TITLE
Fix twilio provider b64encode error in python3

### DIFF
--- a/dbmail/providers/twilio/sms.py
+++ b/dbmail/providers/twilio/sms.py
@@ -29,9 +29,9 @@ def send(sms_to, sms_body, **kwargs):
         "Content-type": "application/x-www-form-urlencoded",
         "User-Agent": "DBMail/%s" % get_version(),
         'Authorization': 'Basic %s' % b64encode(
-            "%s:%s" % (
+            "{}:{}".format(
                 settings.TWILIO_ACCOUNT_SID, settings.TWILIO_AUTH_TOKEN
-            )).decode("ascii")
+            ).encode("utf-8")).decode("ascii")
 
     }
 


### PR DESCRIPTION
Fixes the following error when running with python3:
`TypeError: a bytes-like object is required, not 'str'`

This change changes nothing in python2 but casts to a bytestring in python3 which enables casting to a base64 string in both versions.